### PR TITLE
Travis: use jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.4.0
       gemfile: Gemfile
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       env: JRUBY_OPTS="--profile.api"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html