### PR TITLE
rename options to ctx to match internal naming conventions

### DIFF
--- a/lib/trailblazer/operation/railway/macaroni.rb
+++ b/lib/trailblazer/operation/railway/macaroni.rb
@@ -12,8 +12,8 @@ module Trailblazer
 
       class Option < Trailblazer::Option
         # The Option#call! method prepares the arguments.
-        def self.call!(proc, options, *)
-          proc.( **options.to_hash.merge( options: options ) )
+        def self.call!(proc, ctx, *)
+          proc.( **ctx.to_hash.merge( ctx: ctx ) )
         end
       end
     end

--- a/test/docs/macaroni_test.rb
+++ b/test/docs/macaroni_test.rb
@@ -11,8 +11,8 @@ class MacaroniTaskBuilderTest < Minitest::Spec
     step :create_model, normalizer: Normalizer
     step :save,         normalizer: Normalizer
 
-    def create_model(params:, options:, **)
-      options[:model] = params[:title]
+    def create_model(params:, ctx:, **)
+      ctx[:model] = params[:title]
     end
 
     def save(model:, **)

--- a/test/docs/macaroni_test.rb
+++ b/test/docs/macaroni_test.rb
@@ -16,7 +16,7 @@ class MacaroniTaskBuilderTest < Minitest::Spec
     step :save,         normalizer: Normalizer
 
     def create_model(params:, ctx:, **)
-      options[:model] = Memo.new( title: params[:title] )
+      ctx[:model] = Memo.new( title: params[:title] )
     end
 
     def save( model:, ** )


### PR DESCRIPTION
Follow up to our discussion. This PR renames options for Macaroni to ctx to match internal Trailblazer::Operation::Context naming convention.