### PR TITLE
[POC] Fix duplication at steps pipe

### DIFF
--- a/lib/trailblazer/operation/pipetree.rb
+++ b/lib/trailblazer/operation/pipetree.rb
@@ -86,6 +86,8 @@ class Trailblazer::Operation
       def self.insert(pipe, track, decider_class, proc, options={}) # TODO: make :name required arg.
         _proc, options = proc.is_a?(Array) ? macro!(proc, options) : step!(proc, options)
 
+        index = pipe.instance_variable_get(:@index)
+        options = options.merge(replace: options[:name]) if index.keys.include?(options[:name])
         options = options.merge(replace: options[:name]) if options[:override] # :override
         strut_class, strut_options = AddOptions.(decider_class, options)       # :fail_fast and friends.
 


### PR DESCRIPTION
A bit hackish proof-of-concept, that fixes #22  bug with duplication of steps at railway pipeline.
When rails reloads code, pipetree adds methods to pipeline again, though they are already present here.
Probably this kind of changes should be at pipetree repo?

@apotonick WDYT?

And yeah, these changes are based on 0.0.12 trailblazer-operation gem, because we use it there.
But I'll be able to adopt them to the latest master.