### PR TITLE
add #to_hash and #keys to Result

### DIFF
--- a/.rubocop-https---raw-githubusercontent-com-trailblazer-meta-master-rubocop-yml
+++ b/.rubocop-https---raw-githubusercontent-com-trailblazer-meta-master-rubocop-yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.5.0
   DisplayCopNames: true
 Layout/CaseIndentation:
   IndentOneStep: true
@@ -98,4 +99,17 @@ Layout/AlignHash:
 Metrics/AbcSize:
   Max: 25
 Style/LambdaCall:
+  Enabled: false
+Style/Semicolon:
+  Enabled: false
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Layout/LeadingCommentSpace:
+  Exclude:
+    - 'test/docs/**/*'
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+Style/FrozenStringLiteralComment:
   Enabled: false

--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -29,8 +29,8 @@ module Trailblazer
   class Operation
     module FastTrackActivity
       builder_options = {
-        track_end:     Railway::End::Success.new(semantic: :success),
-        failure_end:   Railway::End::Failure.new(semantic: :failure),
+        track_end: Railway::End::Success.new(semantic: :success),
+        failure_end: Railway::End::Failure.new(semantic: :failure),
         pass_fast_end: Railway::End::PassFast.new(semantic: :pass_fast),
         fail_fast_end: Railway::End::FailFast.new(semantic: :fail_fast)
       }

--- a/lib/trailblazer/operation/inject.rb
+++ b/lib/trailblazer/operation/inject.rb
@@ -10,7 +10,7 @@ module Trailblazer
           extend Activity::Path::Plan()
 
           task ReverseMergeDefaults.new(default_dependencies),
-               id:     "ReverseMergeDefaults#{default_dependencies}",
+               id: "ReverseMergeDefaults#{default_dependencies}",
                before: "task_wrap.call_task"
         end
       end

--- a/lib/trailblazer/operation/inspect.rb
+++ b/lib/trailblazer/operation/inspect.rb
@@ -38,6 +38,7 @@ module Trailblazer
       end
 
       return inspect_line(rows) if options[:style] == :line
+
       return inspect_rows(rows)
     end
 

--- a/lib/trailblazer/operation/public_call.rb
+++ b/lib/trailblazer/operation/public_call.rb
@@ -15,6 +15,7 @@ module Trailblazer
     # @return Operation::Railway::Result binary result object
     def call(*args)
       return call_with_circuit_interface(*args) if args.any? && args[0].is_a?(Array) # This is kind of a hack that could be well hidden if Ruby had method overloading. Goal is to simplify the call/__call__ thing as we're fading out Operation::call anyway.
+
       call_with_public_interface(*args)
     end
 

--- a/lib/trailblazer/operation/railway/normalizer.rb
+++ b/lib/trailblazer/operation/railway/normalizer.rb
@@ -44,6 +44,7 @@ module Trailblazer
 
         def self.raise_on_missing_id(ctx, local_options:, **)
           raise "No :id given for #{local_options[:task]}" unless local_options[:id]
+
           true
         end
 

--- a/lib/trailblazer/operation/result.rb
+++ b/lib/trailblazer/operation/result.rb
@@ -28,6 +28,7 @@ class Trailblazer::Operation
     # DISCUSS: the two methods below are more for testing.
     def inspect(*slices)
       return "<Result:#{success?} #{slice(*slices).inspect} >" if slices.any?
+
       "<Result:#{success?} #{@data.inspect} >"
     end
 

--- a/lib/trailblazer/operation/result.rb
+++ b/lib/trailblazer/operation/result.rb
@@ -14,6 +14,14 @@ class Trailblazer::Operation
       !success?
     end
 
+    def to_hash
+      data.to_hash
+    end
+
+    def keys
+      data.to_hash.keys
+    end
+
     extend Forwardable
     def_delegators :@data, :[] # DISCUSS: make it a real delegator? see Nested.
 
@@ -26,5 +34,9 @@ class Trailblazer::Operation
     def slice(*keys)
       keys.collect { |k| self[k] }
     end
+
+    private
+
+    attr_reader :data
   end
 end

--- a/lib/trailblazer/operation/trace.rb
+++ b/lib/trailblazer/operation/trace.rb
@@ -5,7 +5,7 @@ module Trailblazer
       def self.call(operation, *args)
         ctx = PublicCall.options_for_public_call(*args) # redundant with PublicCall::call.
 
-        stack, signal, (ctx, flow_options) = Activity::Trace.(operation, [ctx, {}])
+        stack, signal, (ctx, _flow_options) = Activity::Trace.(operation, [ctx, {}])
 
         result = Railway::Result(signal, ctx) # redundant with PublicCall::call.
 

--- a/test/operation_test.rb
+++ b/test/operation_test.rb
@@ -32,7 +32,8 @@ class DeclarativeApiTest < Minitest::Spec
 
   it { Create.(decide: true).inspect("a", "x", "y", "b", "c").must_equal %{<Result:true [true, true, false, nil, nil] >} }
   it { Create.(decide: false).inspect("a", "x", "y", "b", "c").must_equal %{<Result:false [true, nil, nil, true, false] >} }
-
+  it { Create.(decide: nil).keys.must_equal(%i(decide a b c)) }
+  it { Create.(decide: nil).to_hash.must_equal(decide: nil, a: true, b: true, c: false) }
   #---
   #- trace
 
@@ -46,6 +47,8 @@ class DeclarativeApiTest < Minitest::Spec
   end
 
   it { Noop.().inspect("params").must_equal %{<Result:true [nil] >} }
+  it { Noop.().keys.must_equal([]) }
+  it { Noop.().to_hash.must_equal({}) }
 
   #---
   #- pass

--- a/test/task_wrap_test.rb
+++ b/test/task_wrap_test.rb
@@ -21,7 +21,7 @@ class TaskWrapTest < Minitest::Spec
             extend Trailblazer::Activity::Path::Plan()
 
             task Trailblazer::Operation::Wrap::Inject::ReverseMergeDefaults.new( contract: "MyDefaultContract" ),
-              id:     "inject.my_default",
+              id: "inject.my_default",
               before: "task_wrap.call_task"
           end
         )
@@ -81,7 +81,7 @@ class TaskWrapTest < Minitest::Spec
             extend Trailblazer::Activity::Path::Plan()
 
             task Trailblazer::Operation::Wrap::Inject::ReverseMergeDefaults.new( another_contract: "AnotherDefaultContract" ), id: "inject.my_default",
-            before: "task_wrap.call_task"
+                                                                                                                               before: "task_wrap.call_task"
           end
         )
       ) => true,


### PR DESCRIPTION
There is currently no way to see a list of keys that are included in a `Result` instance. This is making debugging very tedious sometimes, and also limits the ability for code to explore the results contents.