### PR TITLE
Update trace.rb

### DIFF
--- a/lib/trailblazer/operation/trace.rb
+++ b/lib/trailblazer/operation/trace.rb
@@ -24,7 +24,7 @@ module Trailblazer
 
       # Presentation of the traced stack via the returned result object.
       # This object is wrapped around the original result in {Trace.call}.
-      class Result < SimpleDelegator
+      class Result < ::SimpleDelegator
         def initialize(result, stack)
           super(result)
           @stack = stack


### PR DESCRIPTION
Avoid constant loading problems

On travis have seen some errors like:

> /home/travis/build/user/repo/vendor/bundle/ruby/2.5.0/gems/trailblazer-operation-0.6.0/lib/trailblazer/operation/trace.rb:27:in `<module:Trace>': uninitialized constant Trailblazer::Operation::Trace::SimpleDelegator (NameError)

To avoid, specify `SimpleDelegator` is a top level constant