### PR TITLE
Merge alias branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.6.0
+
+* Require newest `activity` gem.
+
 ## 0.5.3
 
 * New `context` API.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## 0.5.3
 
-* Reintroduce `ClassDependencies` by leveraging `State.fields`.
+* New `context` API.
 
 ## 0.5.2
 

--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -67,6 +67,7 @@ require "trailblazer/operation/deprecated_macro" # TODO: remove in 2.2.
 require "trailblazer/operation/result"
 require "trailblazer/operation/railway"
 
+require "trailblazer/developer"
 require "trailblazer/operation/trace"
 
 require "trailblazer/operation/railway/macaroni"

--- a/lib/trailblazer/operation/public_call.rb
+++ b/lib/trailblazer/operation/public_call.rb
@@ -13,10 +13,10 @@ module Trailblazer
     #
     # @note Do not override this method as it will be removed in future versions. Also, you will break tracing.
     # @return Operation::Railway::Result binary result object
-    def call(*args)
-      return call_with_circuit_interface(*args) if args.any? && args[0].is_a?(Array) # This is kind of a hack that could be well hidden if Ruby had method overloading. Goal is to simplify the call/__call__ thing as we're fading out Operation::call anyway.
+    def call(options = {}, *args)
+      return call_with_circuit_interface(options, *args) if options.is_a?(Array) # This is kind of a hack that could be well hidden if Ruby had method overloading. Goal is to simplify the call/__call__ thing as we're fading out Operation::call anyway.
 
-      call_with_public_interface(*args)
+      call_with_public_interface(options, *args)
     end
 
     def call_with_public_interface(*args)

--- a/lib/trailblazer/operation/public_call.rb
+++ b/lib/trailblazer/operation/public_call.rb
@@ -20,14 +20,14 @@ module Trailblazer
     end
 
     def call_with_public_interface(*args)
-      ctx = options_for_public_call(*args)
+      ctx = options_for_public_call(*args, flow_options())
 
       # call the activity.
       # This will result in invoking {::call_with_circuit_interface}.
       # last_signal, (options, flow_options) = Activity::TaskWrap.invoke(self, [ctx, {}], {})
       signal, (ctx, flow_options) = Activity::TaskWrap.invoke(
         @activity,
-        [ctx, {}],
+        [ctx, flow_options()],
         exec_context: new
       )
 
@@ -46,8 +46,13 @@ module Trailblazer
 
     # Compile a Context object to be passed into the Activity::call.
     # @private
-    def self.options_for_public_call(options={})
-      Trailblazer::Context.for(options, [options, {}], {})
+    def self.options_for_public_call(options={}, flow_options)
+      Trailblazer::Context.for(options, [options, flow_options], {})
+    end
+
+    # @semi=public
+    def flow_options
+      {context_alias: {}}
     end
   end
 end

--- a/lib/trailblazer/operation/public_call.rb
+++ b/lib/trailblazer/operation/public_call.rb
@@ -46,8 +46,8 @@ module Trailblazer
 
     # Compile a Context object to be passed into the Activity::call.
     # @private
-    def self.options_for_public_call(options={}, flow_options)
-      Trailblazer::Context.for(options, [options, flow_options], {})
+    def self.options_for_public_call(options, **flow_options)
+      Trailblazer::Context.for_circuit(options, {}, [options, flow_options], {})
     end
 
     # @semi=public

--- a/lib/trailblazer/operation/trace.rb
+++ b/lib/trailblazer/operation/trace.rb
@@ -5,7 +5,7 @@ module Trailblazer
       def self.call(operation, options)
         ctx = PublicCall.options_for_public_call(options) # redundant with PublicCall::call.
 
-        stack, signal, (ctx, _flow_options) = Activity::Trace.(operation, [ctx, {}])
+        stack, signal, (ctx, _flow_options) = Developer::Trace.(operation, [ctx, {}])
 
         result = Railway::Result(signal, ctx) # redundant with PublicCall::call.
 
@@ -31,7 +31,7 @@ module Trailblazer
         end
 
         def wtf
-          Trailblazer::Activity::Trace::Present.(@stack)
+          Trailblazer::Developer::Trace::Present.(@stack)
         end
 
         def wtf?

--- a/lib/trailblazer/operation/trace.rb
+++ b/lib/trailblazer/operation/trace.rb
@@ -2,8 +2,8 @@ module Trailblazer
   class Operation
     module Trace
       # @note The problem in this method is, we have redundancy with Operation::PublicCall
-      def self.call(operation, *args)
-        ctx = PublicCall.options_for_public_call(*args) # redundant with PublicCall::call.
+      def self.call(operation, options)
+        ctx = PublicCall.options_for_public_call(options) # redundant with PublicCall::call.
 
         stack, signal, (ctx, _flow_options) = Activity::Trace.(operation, [ctx, {}])
 
@@ -18,8 +18,8 @@ module Trailblazer
       # @public
       #
       #   Operation.trace(params, current_user: current_user).wtf
-      def trace(*args)
-        Trace.(self, *args)
+      def trace(options)
+        Trace.(self, options)
       end
 
       # Presentation of the traced stack via the returned result object.

--- a/lib/trailblazer/operation/version.rb
+++ b/lib/trailblazer/operation/version.rb
@@ -1,7 +1,7 @@
 module Trailblazer
   module Version
     module Operation
-      VERSION = "0.5.2"
+      VERSION = "0.5.3"
     end
   end
 end

--- a/lib/trailblazer/operation/version.rb
+++ b/lib/trailblazer/operation/version.rb
@@ -1,7 +1,7 @@
 module Trailblazer
   module Version
     module Operation
-      VERSION = "0.5.3"
+      VERSION = "0.6.0"
     end
   end
 end

--- a/test/call_test.rb
+++ b/test/call_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+  require "test_helper"
 
 class CallTest < Minitest::Spec
   class Create < Trailblazer::Operation

--- a/test/trace_test.rb
+++ b/test/trace_test.rb
@@ -17,7 +17,7 @@ class TraceTest < Minitest::Spec
   it "allows using low-level Activity::Trace" do
     ->(*args) { puts "@@@@@ #{args.last.inspect}"; Create.__call__(*args) }
 
-    stack, = Trailblazer::Activity::Trace.(
+    stack, = Trailblazer::Developer::Trace.(
       Create,
       [
         {a_return: true, params: {}},
@@ -25,7 +25,7 @@ class TraceTest < Minitest::Spec
       ]
     )
 
-    puts output = Trailblazer::Activity::Trace::Present.(stack)
+    puts output = Trailblazer::Developer::Trace::Present.(stack)
 
     output.gsub(/0x\w+/, "").gsub(/@.+_test/, "").must_equal %{`-- TraceTest::Create
    |-- Start.default

--- a/test/trace_test.rb
+++ b/test/trace_test.rb
@@ -28,30 +28,30 @@ class TraceTest < Minitest::Spec
     puts output = Trailblazer::Developer::Trace::Present.(stack)
 
     output.gsub(/0x\w+/, "").gsub(/@.+_test/, "").must_equal %{`-- TraceTest::Create
-   |-- Start.default
-   |-- Create.task.a
-   |-- MyNested
-   |   |-- Start.default
-   |   |-- B.task.b
-   |   |-- B.task.e
-   |   `-- End.success
-   |-- Create.task.c
-   |-- Create.task.params
-   `-- End.failure}
+    |-- Start.default
+    |-- Create.task.a
+    |-- MyNested
+    |   |-- Start.default
+    |   |-- B.task.b
+    |   |-- B.task.e
+    |   `-- End.success
+    |-- Create.task.c
+    |-- Create.task.params
+    `-- End.failure}
   end
 
   it "Operation::trace" do
     result = Create.trace(params: {x: 1}, a_return: true)
     result.wtf.gsub(/0x\w+/, "").gsub(/@.+_test/, "").must_equal %{`-- TraceTest::Create
-   |-- Start.default
-   |-- Create.task.a
-   |-- MyNested
-   |   |-- Start.default
-   |   |-- B.task.b
-   |   |-- B.task.e
-   |   `-- End.success
-   |-- Create.task.c
-   |-- Create.task.params
-   `-- End.success}
+    |-- Start.default
+    |-- Create.task.a
+    |-- MyNested
+    |   |-- Start.default
+    |   |-- B.task.b
+    |   |-- B.task.e
+    |   `-- End.success
+    |-- Create.task.c
+    |-- Create.task.params
+    `-- End.success}
   end
 end

--- a/trailblazer-operation.gemspec
+++ b/trailblazer-operation.gemspec
@@ -18,12 +18,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "trailblazer-activity-dsl-linear", ">= 0.2.6", "< 1.0.0"
+  spec.add_dependency "trailblazer-activity", ">= 0.10.0", "< 1.0.0"
+  spec.add_dependency "trailblazer-developer", ">= 0.0.8"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "trailblazer-developer", ">= 0.0.3"
 
   spec.required_ruby_version = ">= 2.1.0"
 end


### PR DESCRIPTION
- Rebases with published changes (on rubygems) into `master`. (`0.5.3` and `0.6.0` seems to be released from `alias` branch and not master).
- Uses `Dev::Trace` and fixes `Uninitialized constant Activity::Trace` error

Should we release `ClassDependancy` changes in new version ? They're not released in `0.5.3`