### PR TITLE
require 'delegate' explicitly

### DIFF
--- a/lib/trailblazer/operation/trace.rb
+++ b/lib/trailblazer/operation/trace.rb
@@ -1,3 +1,5 @@
+require 'delegate'
+
 module Trailblazer
   class Operation
     module Trace

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,9 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "trailblazer/operation"
+
 require "pp"
 
 require "minitest/autorun"
-require "trailblazer/operation"
 require "trailblazer/activity/testing"
 require "trailblazer/developer/render/linear"
 

--- a/test/trace_test.rb
+++ b/test/trace_test.rb
@@ -14,18 +14,13 @@ class TraceTest < Minitest::Spec
   end
   # raise Create["__task_wraps__"].inspect
 
-  it "allows using low-level Activity::Trace" do
-    ->(*args) { puts "@@@@@ #{args.last.inspect}"; Create.__call__(*args) }
-
-    stack, = Trailblazer::Developer::Trace.(
+  it "allows using low-level Operation::Trace" do
+    result = Trailblazer::Operation::Trace.(
       Create,
-      [
-        {a_return: true, params: {}},
-        {}
-      ]
+      { a_return: true, params: {} },
     )
 
-    puts output = Trailblazer::Developer::Trace::Present.(stack)
+    output = result.wtf
 
     output.gsub(/0x\w+/, "").gsub(/@.+_test/, "").must_equal %{`-- TraceTest::Create
     |-- Start.default


### PR DESCRIPTION
It's not required on local setups but on travis or on some platforms
resolves #21
Modify trace_test to use Operation::Trace