### PR TITLE
Add `Operation::wtf`

### DIFF
--- a/lib/trailblazer/operation/trace.rb
+++ b/lib/trailblazer/operation/trace.rb
@@ -25,6 +25,11 @@ module Trailblazer
         Trace.(self, options)
       end
 
+      def wtf(options)
+        Developer.wtf(self, options)
+      end
+      alias_method :wtf?, :wtf
+
       # Presentation of the traced stack via the returned result object.
       # This object is wrapped around the original result in {Trace.call}.
       class Result < ::SimpleDelegator

--- a/test/trace_test.rb
+++ b/test/trace_test.rb
@@ -49,4 +49,27 @@ class TraceTest < Minitest::Spec
     |-- Create.task.params
     `-- End.success}
   end
+
+  it "Operation::wtf" do
+    output, _ = capture_io do
+      Create.wtf?(params: {x: 1}, a_return: true)
+    end
+
+    _(output).must_equal %{`-- TraceTest::Create
+    |-- \e[32mStart.default\e[0m
+    |-- \e[32mCreate.task.a\e[0m
+    |-- MyNested
+    |   |-- \e[32mStart.default\e[0m
+    |   |-- \e[32mB.task.b\e[0m
+    |   |-- \e[32mB.task.e\e[0m
+    |   `-- End.success
+    |-- \e[32mCreate.task.c\e[0m
+    |-- \e[32mCreate.task.params\e[0m
+    `-- End.success
+}
+  end
+
+  it "Operation::wtf?" do
+    assert_equal Create.method(:wtf), Create.method(:wtf?)
+  end
 end


### PR DESCRIPTION
Allow `wtf?` on the `Operation` itself.

```ruby
Create.wtf?(params: params)
```