### PR TITLE
Upgrade activity & DSL version

### DIFF
--- a/trailblazer-operation.gemspec
+++ b/trailblazer-operation.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "trailblazer-activity-dsl-linear", ">= 0.4.0", "< 1.0.0"
-  spec.add_dependency "trailblazer-activity", ">= 0.12.1", "< 1.0.0"
+  spec.add_dependency "trailblazer-activity-dsl-linear", ">= 0.4.1", "< 1.0.0"
+  spec.add_dependency "trailblazer-activity", ">= 0.12.2", "< 1.0.0"
   spec.add_dependency "trailblazer-developer", ">= 0.0.21", "< 1.0.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Upgrading version in order to resolve conflict with `Trailblazer::Option` class and use extracted gem.