### PR TITLE
DRAFT: extract ciruit_options when using public call interface

### DIFF
--- a/lib/trailblazer/operation/public_call.rb
+++ b/lib/trailblazer/operation/public_call.rb
@@ -21,11 +21,13 @@ module Trailblazer
 
     # @private Please do not override this method as it might get removed.
     def call_with_public_interface_from_call(options, flow_options, **circuit_options)
+      # extract valid circuit options (what is the definitive source for available circuit options?)
+      real_circuit_options, other_options = circuit_options.partition {|k,_v| reserved_circuit_option_names.include? k }.map(&:to_h)
       # normalize options.
       options = options
-        .merge(circuit_options) # when using Op.call(params:, ...), {circuit_options} will always be ctx variables.
+        .merge(other_options) # when using Op.call(params:, ...), {circuit_options} will always be ctx variables.
 
-      call_with_public_interface(options, flow_options)
+      call_with_public_interface(options, flow_options, real_circuit_options)
     end
 
     # Default {@activity} call interface which doesn't accept {circuit_options}
@@ -118,6 +120,10 @@ module Trailblazer
 
     def initial_wrap_static
       INITIAL_WRAP_STATIC
+    end
+
+    def reserved_circuit_option_names
+      %i(wrap_runtime)
     end
   end
 end

--- a/test/call_test.rb
+++ b/test/call_test.rb
@@ -70,4 +70,66 @@ class CallTest < Minitest::Spec
 
     result.wtf?
   end
+
+  it "invokes with the taskWrap defined at operation" do
+    operation = Class.new(Trailblazer::Operation) do
+      include Trailblazer::Activity::Testing.def_steps(:a)
+
+      def self.add_1(wrap_ctx, original_args)
+        ctx, = original_args[0]
+        ctx[:seq] << 1
+        return wrap_ctx, original_args # yay to mutable state. not.
+      end
+
+      step :a
+    end
+
+    my_extension = Trailblazer::Activity::TaskWrap::Extension(
+      [operation.method(:add_1), id: "my.add_1", append: "task_wrap.call_task"]
+    )
+
+    # normal operation invocation
+    ctx = { seq: [] }
+    signal, (ctx, _) = operation.invoke([ctx, {}], wrap_runtime: Hash.new(my_extension))
+    signal.to_h[:semantic].must_equal :success
+    ctx[:seq].must_equal [1, :a, 1, 1, 1]
+
+    # with tracing
+    result = operation.trace(seq: [])
+
+    result.inspect(:seq).must_equal %{<Result:true [[:a]] >}
+
+    result.wtf?
+  end
+
+  it "calls with the taskWrap defined at operation" do
+    operation = Class.new(Trailblazer::Operation) do
+      include Trailblazer::Activity::Testing.def_steps(:a)
+
+      def self.add_1(wrap_ctx, original_args)
+        ctx, = original_args[0]
+        ctx[:seq] << 1
+        return wrap_ctx, original_args # yay to mutable state. not.
+      end
+
+      step :a
+    end
+
+    my_extension = Trailblazer::Activity::TaskWrap::Extension(
+      [operation.method(:add_1), id: "my.add_1", append: "task_wrap.call_task"]
+    )
+
+    # normal operation invocation
+    ctx = { seq: [] }
+    signal, (ctx, _) = operation.call([ctx, {}], wrap_runtime: Hash.new(my_extension))
+    signal.to_h[:semantic].must_equal :success
+    ctx[:seq].must_equal [1, :a, 1, 1, 1]
+
+    # with tracing
+    result = operation.trace(seq: [])
+
+    result.inspect(:seq).must_equal %{<Result:true [[:a]] >}
+
+    result.wtf?
+  end
 end


### PR DESCRIPTION
When providing circuit options while using the public call interface, these should be taken into account.

In order to do this we filter out known circuit options before merging all into the options.

Open question: Is there a definitive source for circuit_options keys?

Also I noticed, when using call with the circuit interface the circuit options are picked up, but get lost later in the process. See added specs in call_test.rb